### PR TITLE
Always call JOSM over http

### DIFF
--- a/app/osm_observer/webapp/src/app/josmlink/josmlink.component.ts
+++ b/app/osm_observer/webapp/src/app/josmlink/josmlink.component.ts
@@ -28,9 +28,7 @@ export class JOSMLinkComponent implements OnInit {
   }
 
   private buildJSOMUrl(protocol) {
-    let url = protocol === 'https:' ?
-      'https://127.0.0.1.8112/load_and_zoom?' :
-      'http://127.0.0.1:8111/load_and_zoom?';
+    let url = 'http://127.0.0.1:8111/load_and_zoom?';
     let params = [
       'left=' + this.changeset.dataBBOX[0],
       'right=' + this.changeset.dataBBOX[2],


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

w3c/webappsec-mixed-content@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.